### PR TITLE
Make MacOS installation Brew Boost version agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,16 @@ or alternatively, to update the environment (needed after adding a dependency),
 
 ### Install the Boost libraries 
 
-Install the C++ Boost libraries needed to integrate the multi-strain SIR model,
+Install the C++ Boost libraries needed to integrate the multi-strain SIR model, for Linux users,
 
     ```bash
     sudo apt-get update && sudo apt-get install -y libboost-all-dev
+    ```
+
+Mac users **must** install Boost through Homebrew,
+
+    ```bash
+    brew install boost
     ```
 
 Note: Boost is a C++ library and is not installed "inside" the conda environment but rather on your local machine. In `setup.py` the software is pointed to the location of the Boost library.
@@ -45,6 +51,7 @@ Note: Boost is a C++ library and is not installed "inside" the conda environment
 Install the `hierarchSIR` Python package inside the conda environment using,
 
     ```bash
+    conda activate HIERARCHSIR
     pip install -e . --force-reinstall
     ```
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import glob
 import platform
 import pybind11
 from setuptools import setup, Extension
@@ -16,7 +17,10 @@ def find_boost_include():
         return '/usr/include'
     # Or macOS
     elif platform.system() == 'Darwin':
-        return '/opt/homebrew/Cellar/boost/1.87.0_1/include'
+        candidates = glob.glob('/opt/homebrew/Cellar/boost/*/include')
+        if candidates:
+            return candidates[-1]  # Choose the latest version
+        raise FileNotFoundError("Boost include path not found via Homebrew")
     else:
         raise RuntimeError("Unsupported OS")
 
@@ -30,7 +34,10 @@ def find_boost_lib():
         return '/usr/lib/x86_64-linux-gnu'
     # Or macOS
     elif platform.system() == 'Darwin':
-        return '/opt/homebrew/Cellar/boost/1.87.0_1/lib'
+        candidates = glob.glob('/opt/homebrew/Cellar/boost/*/lib')
+        if candidates:
+            return candidates[-1]
+        raise FileNotFoundError("Boost lib path not found via Homebrew")
     else:
         raise RuntimeError("Unsupported OS")
 


### PR DESCRIPTION
Using `glob` in `setup.py` to automatically select the latest Boost version.